### PR TITLE
Agregado el controlador para verificar si un número es par o impar

### DIFF
--- a/ParInpar/Controllers/NumeroController.cs
+++ b/ParInpar/Controllers/NumeroController.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace ParInpar.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class NumeroController : ControllerBase
+    {
+        [HttpGet("verificar/{numero}")]
+        public IActionResult VerificarParImpar(int numero)
+        {
+            if (numero % 2 == 0)
+            {
+                return Ok($"El número {numero} es PAR.");
+            }
+            else
+            {
+                return Ok($"El número {numero} es IMPAR.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Se añadió un nuevo controlador llamado NumeroController para verificar si un número es par o impar mediante un endpoint /api/numero/verificar/{numero}.